### PR TITLE
Remove post for clean release version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ Issues = "https://github.com/diffpy/diffpy.utils/issues"
 [tool.setuptools-git-versioning]
 enabled = true
 template = "{tag}"
-dev_template = "{tag}.post{ccount}"
-dirty_template = "{tag}.post{ccount}"
+dev_template = "{tag}"
+dirty_template = "{tag}"
 
 [tool.setuptools.packages.find]
 where = ["src"]  # list of folders that contain the packages (["."] by default)


### PR DESCRIPTION
Improper handling of github tags will cause post to be tacked onto the release version. This ensure release version will be a clean release number in exchange for post information.